### PR TITLE
Added wavelength to target model

### DIFF
--- a/prisma/migrations/20250110184203_/migration.sql
+++ b/prisma/migrations/20250110184203_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Target" ADD COLUMN     "wavelength" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,14 +41,15 @@ enum GuidingType {
 }
 
 model Target {
-  pk        Int        @id @default(autoincrement())
-  id        String?
-  name      String     @default("Test")
-  coord1    Float // RA or Az
-  coord2    Float // Dec or El
-  epoch     String     @default("J2000.000")
-  type      TargetType @default(SCIENCE) // FIXED | SCIENCE | BLINDOFFSET | OIWFS | PWFS1 | PWFS2
-  createdAt DateTime   @default(now())
+  pk         Int        @id @default(autoincrement())
+  id         String?
+  name       String     @default("Test")
+  coord1     Float // RA or Az
+  coord2     Float // Dec or El
+  epoch      String     @default("J2000.000")
+  type       TargetType @default(SCIENCE) // FIXED | SCIENCE | BLINDOFFSET | OIWFS | PWFS1 | PWFS2
+  wavelength Int?
+  createdAt  DateTime   @default(now())
 }
 
 enum TargetType {

--- a/src/graphql/gen/index.ts
+++ b/src/graphql/gen/index.ts
@@ -260,6 +260,7 @@ export type MutationCreateTargetArgs = {
   name: Scalars['String']['input'];
   ra?: InputMaybe<Scalars['Float']['input']>;
   type: TargetType;
+  wavelength?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -444,6 +445,7 @@ export type MutationUpdateTargetArgs = {
   name?: InputMaybe<Scalars['String']['input']>;
   pk: Scalars['Int']['input'];
   type?: InputMaybe<TargetType>;
+  wavelength?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type Query = {
@@ -567,6 +569,7 @@ export type Target = {
   pk: Scalars['Int']['output'];
   ra?: Maybe<Ra>;
   type: TargetType;
+  wavelength?: Maybe<Scalars['Int']['output']>;
 };
 
 export type TargetInput = {
@@ -576,6 +579,7 @@ export type TargetInput = {
   id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
   type?: InputMaybe<Scalars['String']['input']>;
+  wavelength?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type TargetType =
@@ -1015,6 +1019,7 @@ export type TargetResolvers<ContextType = ApolloContext, ParentType extends Reso
   pk?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   ra?: Resolver<Maybe<ResolversTypes['RA']>, ParentType, ContextType>;
   type?: Resolver<ResolversTypes['TargetType'], ParentType, ContextType>;
+  wavelength?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/src/graphql/types/Target.ts
+++ b/src/graphql/types/Target.ts
@@ -39,6 +39,7 @@ export const TargetTypeDefs = `#graphql
     dec: Dec            # Declination
     epoch: String!       # Epoch of target
     type: TargetType!    # FIXED | SCIENCE | BLINDOFFSET | PWFS1 | PWFS2 | OIWFS
+    wavelength: Int      # Wavelength
     createdAt: DateTime!   # Datetime when it was created
   }
 
@@ -57,6 +58,7 @@ export const TargetTypeDefs = `#graphql
     coord2: Float
     epoch: String
     type: String
+    wavelength: Int
   }
 
   type Mutation {
@@ -69,6 +71,7 @@ export const TargetTypeDefs = `#graphql
       el: Float
       epoch: String
       type: TargetType!
+      wavelength: Int
     ): Target!
 
     updateTarget(
@@ -79,6 +82,7 @@ export const TargetTypeDefs = `#graphql
       coord2: Float
       epoch: String
       type: TargetType
+      wavelength: Int
     ): Target!
 
     removeAndCreateBaseTargets(


### PR DESCRIPTION
Target now can store an optional wavelength, used to send the central wavelength in target slew and target swap