### PR TITLE
Added prisma generate to start-server.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ FROM base
 ENV NODE_ENV=production
 ENV COREPACK_ENABLE_NETWORK=0
 
+# Generate prisma client
+RUN pnpx prisma generate
+
 # Copy built files
 COPY --from=prod-deps --chown=software:software /usr/src/app/node_modules /usr/src/app/node_modules
 COPY --from=build --chown=software:software /usr/src/app/dist /usr/src/app/dist

--- a/start-server.sh
+++ b/start-server.sh
@@ -8,6 +8,7 @@ if [ ! -e $CONTAINER_ALREADY_STARTED ]; then
 else
     echo "-- Not first container startup --"
     echo "-- Running migrations --"
+    pnpm prisma generate
     pnpm prisma migrate deploy
     echo "-- Starting server --"
     pnpm preview

--- a/start-server.sh
+++ b/start-server.sh
@@ -8,7 +8,6 @@ if [ ! -e $CONTAINER_ALREADY_STARTED ]; then
 else
     echo "-- Not first container startup --"
     echo "-- Running migrations --"
-    pnpm prisma generate
     pnpm prisma migrate deploy
     echo "-- Starting server --"
     pnpm preview


### PR DESCRIPTION
Navigate-configs container was complaining "PrismaClient" not found.
Prisma generate command should be run on startup, this was done by prisma migrate before, but it is not working anymore, then it was explicitly added to start-server.sh script.