### PR TITLE
Allow prisma client in postinstall scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,10 @@
     "dist",
     "prisma",
     "src"
-  ]
+  ],
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@prisma/client"
+    ]
+  }
 }


### PR DESCRIPTION
Related to #254 

Pnpm recently changed what is allowed to run as postinstall scripts. So we need to manually add @prisma/client to this list